### PR TITLE
Graphs are equal iff they have the same interface

### DIFF
--- a/core/src/main/java/com/spbsu/flamestream/core/graph/AbstractAtomicGraph.java
+++ b/core/src/main/java/com/spbsu/flamestream/core/graph/AbstractAtomicGraph.java
@@ -1,6 +1,7 @@
 package com.spbsu.flamestream.core.graph;
 
 import java.util.Collections;
+import java.util.Objects;
 
 public abstract class AbstractAtomicGraph implements AtomicGraph {
   private int localTime = 0;
@@ -13,5 +14,23 @@ public abstract class AbstractAtomicGraph implements AtomicGraph {
   @Override
   public final ComposedGraph<AtomicGraph> flattened() {
     return new ComposedGraphImpl<>(Collections.singleton(this));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AbstractAtomicGraph that = (AbstractAtomicGraph) o;
+    return that.inPorts().equals(inPorts())
+            && that.outPorts().equals(outPorts());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(inPorts(), outPorts());
   }
 }

--- a/core/src/main/java/com/spbsu/flamestream/core/graph/ChaincallGraph.java
+++ b/core/src/main/java/com/spbsu/flamestream/core/graph/ChaincallGraph.java
@@ -8,8 +8,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
-public final class ChaincallGraph implements AtomicGraph {
+public final class ChaincallGraph extends AbstractAtomicGraph {
   private final ComposedGraph<AtomicGraph> composedGraph;
   private final Map<InPort, AtomicGraph> upstreams = new HashMap<>();
 
@@ -54,8 +55,21 @@ public final class ChaincallGraph implements AtomicGraph {
   }
 
   @Override
-  public ComposedGraph<AtomicGraph> flattened() {
-    return new ComposedGraphImpl<>(Collections.singleton(this));
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ChaincallGraph that = (ChaincallGraph) o;
+    return Objects.equals(composedGraph, that.composedGraph) &&
+            Objects.equals(upstreams, that.upstreams);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(composedGraph, upstreams);
   }
 
   private final class ChainHandle implements AtomicHandle {

--- a/core/src/main/java/com/spbsu/flamestream/core/graph/ComposedGraphImpl.java
+++ b/core/src/main/java/com/spbsu/flamestream/core/graph/ComposedGraphImpl.java
@@ -93,4 +93,24 @@ public final class ComposedGraphImpl<T extends Graph> implements ComposedGraph<T
   public Map<OutPort, InPort> downstreams() {
     return Collections.unmodifiableMap(downstreams);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ComposedGraphImpl<?> that = (ComposedGraphImpl<?>) o;
+    return Objects.equals(downstreams, that.downstreams) &&
+            Objects.equals(inPorts, that.inPorts) &&
+            Objects.equals(outPorts, that.outPorts) &&
+            Objects.equals(subGraphs, that.subGraphs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(downstreams, inPorts, outPorts, subGraphs);
+  }
 }

--- a/core/src/main/java/com/spbsu/flamestream/core/graph/barrier/BarrierSink.java
+++ b/core/src/main/java/com/spbsu/flamestream/core/graph/barrier/BarrierSink.java
@@ -13,7 +13,7 @@ import static java.lang.String.format;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 
-final class BarrierSink implements AtomicGraph {
+final class BarrierSink extends AbstractAtomicGraph {
   private final ChaincallGraph innerGraph;
 
   BarrierSink(AtomicGraph sink) {
@@ -41,11 +41,6 @@ final class BarrierSink implements AtomicGraph {
   @Override
   public List<OutPort> outPorts() {
     return innerGraph.outPorts();
-  }
-
-  @Override
-  public ComposedGraph<AtomicGraph> flattened() {
-    return new ComposedGraphImpl<>(singleton(this));
   }
 
   @Override

--- a/core/src/main/java/com/spbsu/flamestream/core/graph/barrier/BarrierSuite.java
+++ b/core/src/main/java/com/spbsu/flamestream/core/graph/barrier/BarrierSuite.java
@@ -3,6 +3,7 @@ package com.spbsu.flamestream.core.graph.barrier;
 import com.spbsu.flamestream.core.graph.*;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.ToIntFunction;
 
 import static java.util.Collections.emptyList;
@@ -36,5 +37,23 @@ public final class BarrierSuite<T> implements Graph {
   @Override
   public ComposedGraph<AtomicGraph> flattened() {
     return preBarrierMetaFilter.fuse(barrierSink, preBarrierMetaFilter.outPort(), barrierSink.inPort()).flattened();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BarrierSuite<?> that = (BarrierSuite<?>) o;
+    return Objects.equals(preBarrierMetaFilter, that.preBarrierMetaFilter) &&
+            Objects.equals(barrierSink, that.barrierSink);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(preBarrierMetaFilter, barrierSink);
   }
 }


### PR DESCRIPTION
Graphs are equal if and only if they have the same ports.

Such approach makes sense as later each input would be associated with some type. Also, it relieves the need to implement `equals` & `hashCode` in each `HashFunction`