### PR TITLE
FlameRuntime.Flame#attachRear should not expose list of workers

### DIFF
--- a/examples/src/main/java/com/spbsu/flamestream/example/benchmark/InvertedIndexBenchmark.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/benchmark/InvertedIndexBenchmark.java
@@ -32,14 +32,14 @@ public class InvertedIndexBenchmark {
       final ConcurrentSkipListMap<Integer, LatencyMeasurer> latencies = new ConcurrentSkipListMap<>();
       final AwaitCountConsumer awaitConsumer = new AwaitCountConsumer(65813);
       flame.attachRear("Rear", new AkkaRearType<>(runtime.system(), WordBase.class))
-              .forEach(r -> r.addListener(wordBase -> {
+              .addListener(wordBase -> {
                 awaitConsumer.accept(wordBase);
                 if (wordBase instanceof WordIndexAdd) {
                   final WordIndexAdd indexAdd = (WordIndexAdd) wordBase;
                   final int docId = IndexItemInLong.pageId(indexAdd.positions()[0]);
                   latencies.get(docId).finish();
                 }
-              }));
+              });
 
       final List<AkkaFront.FrontHandle<WikipediaPage>> handles = flame
               .attachFront("Front", new AkkaFrontType<WikipediaPage>(runtime.system()))

--- a/examples/src/main/java/com/spbsu/flamestream/example/benchmark/blink/BlinkBenchStand.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/benchmark/blink/BlinkBenchStand.java
@@ -86,7 +86,7 @@ public class BlinkBenchStand implements AutoCloseable {
 
     try (FlameRuntime.Flame flame = runtime.run(new InvertedIndexGraph().get())) {
       flame.attachRear("wikirear", new AkkaRearType<>(system, WordBase.class))
-              .forEach(r -> r.addListener(wordBase -> {
+              .addListener(wordBase -> {
                 final WordIndexAdd wordIndexAdd;
                 if (wordBase instanceof WordIndexAdd) {
                   wordIndexAdd = (WordIndexAdd) wordBase;
@@ -102,7 +102,7 @@ public class BlinkBenchStand implements AutoCloseable {
                   LOG.info("Progress: {}/{}", awaitConsumer.got(), awaitConsumer.expected());
                 }
 
-              }));
+              });
 
       final List<AkkaFront.FrontHandle<Object>> consumers =
               flame.attachFront("wikifront", new AkkaFrontType<>(system, true))

--- a/examples/src/test/java/com/spbsu/flamestream/example/bl/index/InvertedIndexTest.java
+++ b/examples/src/test/java/com/spbsu/flamestream/example/bl/index/InvertedIndexTest.java
@@ -40,7 +40,7 @@ public class InvertedIndexTest extends FlameAkkaSuite {
         final String invocationConfig = validator.getClass().getSimpleName() + "-bp-" + backPressure;
         final AwaitResultConsumer<WordBase> awaitConsumer = new AwaitResultConsumer<>(validator.expectedOutputSize());
         flame.attachRear("Rear-" + invocationConfig, new AkkaRearType<>(runtime.system(), WordBase.class))
-                .forEach(r -> r.addListener(awaitConsumer));
+                .addListener(awaitConsumer);
 
         final List<AkkaFront.FrontHandle<Object>> consumers =
                 flame.attachFront("Front-" + invocationConfig, new AkkaFrontType<>(runtime.system(), backPressure))

--- a/examples/src/test/java/com/spbsu/flamestream/example/bl/topwordcount/TopWordCountGraphTest.java
+++ b/examples/src/test/java/com/spbsu/flamestream/example/bl/topwordcount/TopWordCountGraphTest.java
@@ -56,7 +56,7 @@ public class TopWordCountGraphTest extends FlameAkkaSuite {
                 lineSize * streamSize
         );
         flame.attachRear("wordCountRear", new AkkaRearType<>(runtime.system(), WordsTop.class))
-                .forEach(r -> r.addListener(awaitConsumer));
+                .addListener(awaitConsumer);
         final List<AkkaFront.FrontHandle<String>> handles = flame
                 .attachFront("wordCountFront", new AkkaFrontType<String>(runtime.system()))
                 .collect(Collectors.toList());

--- a/examples/src/test/java/com/spbsu/flamestream/example/bl/wordcount/WordCountTest.java
+++ b/examples/src/test/java/com/spbsu/flamestream/example/bl/wordcount/WordCountTest.java
@@ -56,7 +56,7 @@ public class WordCountTest extends FlameAkkaSuite {
                 lineSize * streamSize
         );
         flame.attachRear("wordCountRear", new AkkaRearType<>(runtime.system(), WordCounter.class))
-                .forEach(r -> r.addListener(awaitConsumer));
+                .addListener(awaitConsumer);
         final List<AkkaFront.FrontHandle<String>> handles = flame
                 .attachFront("wordCountFront", new AkkaFrontType<String>(runtime.system()))
                 .collect(Collectors.toList());

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -125,6 +125,11 @@
             <groupId>kryonet</groupId>
             <artifactId>kryonet</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.reactfx</groupId>
+            <artifactId>reactfx</artifactId>
+            <version>2.0-M5</version>
+        </dependency>
 
         <!--Tests-->
         <dependency>

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/FlameRuntime.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/FlameRuntime.java
@@ -4,6 +4,7 @@ import com.spbsu.flamestream.runtime.edge.Front;
 import com.spbsu.flamestream.core.Graph;
 import com.spbsu.flamestream.runtime.edge.Rear;
 import com.spbsu.flamestream.runtime.edge.EdgeContext;
+import javafx.collections.ObservableSet;
 
 import java.util.stream.Stream;
 
@@ -21,7 +22,7 @@ public interface FlameRuntime extends AutoCloseable {
   interface Flame extends AutoCloseable {
     <F extends Front, H> Stream<H> attachFront(String id, FrontType<F, H> type);
 
-    <R extends Rear, H> Stream<H> attachRear(String id, RearType<R, H> type);
+    <R extends Rear, H> H attachRear(String id, RearType<R, H> type);
 
     @Override
     default void close() {
@@ -37,7 +38,7 @@ public interface FlameRuntime extends AutoCloseable {
   interface RearType<R extends Rear, H> {
     RearInstance<R> instance();
 
-    H handle(EdgeContext context);
+    H handles(ObservableSet<EdgeContext> context);
   }
 
   interface FrontInstance<F extends Front> {

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/FlameRuntime.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/FlameRuntime.java
@@ -4,7 +4,7 @@ import com.spbsu.flamestream.runtime.edge.Front;
 import com.spbsu.flamestream.core.Graph;
 import com.spbsu.flamestream.runtime.edge.Rear;
 import com.spbsu.flamestream.runtime.edge.EdgeContext;
-import javafx.collections.ObservableList;
+import org.reactfx.collection.LiveList;
 
 import java.util.stream.Stream;
 
@@ -38,7 +38,7 @@ public interface FlameRuntime extends AutoCloseable {
   interface RearType<R extends Rear, H> {
     RearInstance<R> instance();
 
-    H handles(ObservableList<EdgeContext> context);
+    H handles(LiveList<EdgeContext> context);
   }
 
   interface FrontInstance<F extends Front> {

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/FlameRuntime.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/FlameRuntime.java
@@ -4,7 +4,7 @@ import com.spbsu.flamestream.runtime.edge.Front;
 import com.spbsu.flamestream.core.Graph;
 import com.spbsu.flamestream.runtime.edge.Rear;
 import com.spbsu.flamestream.runtime.edge.EdgeContext;
-import javafx.collections.ObservableSet;
+import javafx.collections.ObservableList;
 
 import java.util.stream.Stream;
 
@@ -38,7 +38,7 @@ public interface FlameRuntime extends AutoCloseable {
   interface RearType<R extends Rear, H> {
     RearInstance<R> instance();
 
-    H handles(ObservableSet<EdgeContext> context);
+    H handles(ObservableList<EdgeContext> context);
   }
 
   interface FrontInstance<F extends Front> {

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/RemoteRuntime.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/RemoteRuntime.java
@@ -6,8 +6,8 @@ import com.spbsu.flamestream.runtime.edge.Front;
 import com.spbsu.flamestream.runtime.edge.Rear;
 import com.spbsu.flamestream.runtime.edge.SystemEdgeContext;
 import com.spbsu.flamestream.runtime.serialization.FlameSerializer;
-import javafx.collections.FXCollections;
 import org.apache.curator.framework.CuratorFramework;
+import org.reactfx.collection.LiveArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,11 +77,11 @@ public class RemoteRuntime implements FlameRuntime {
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
-      return type.handles(FXCollections.unmodifiableObservableList(FXCollections.observableList(clusterConfig.paths()
+      return type.handles(new LiveArrayList<>(clusterConfig.paths()
               .entrySet()
               .stream()
               .map(e -> new SystemEdgeContext(e.getValue(), e.getKey(), id))
-              .collect(Collectors.toList()))));
+              .collect(Collectors.toList())));
     }
   }
 }

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/RemoteRuntime.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/RemoteRuntime.java
@@ -77,11 +77,11 @@ public class RemoteRuntime implements FlameRuntime {
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
-      return type.handles(FXCollections.observableSet(clusterConfig.paths()
+      return type.handles(FXCollections.unmodifiableObservableSet(FXCollections.observableSet(clusterConfig.paths()
               .entrySet()
               .stream()
               .map(e -> new SystemEdgeContext(e.getValue(), e.getKey(), id))
-              .collect(Collectors.toSet())));
+              .collect(Collectors.toSet()))));
     }
   }
 }

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/RemoteRuntime.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/RemoteRuntime.java
@@ -77,11 +77,11 @@ public class RemoteRuntime implements FlameRuntime {
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
-      return type.handles(FXCollections.unmodifiableObservableSet(FXCollections.observableSet(clusterConfig.paths()
+      return type.handles(FXCollections.unmodifiableObservableList(FXCollections.observableList(clusterConfig.paths()
               .entrySet()
               .stream()
               .map(e -> new SystemEdgeContext(e.getValue(), e.getKey(), id))
-              .collect(Collectors.toSet()))));
+              .collect(Collectors.toList()))));
     }
   }
 }

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/akka/AkkaRear.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/akka/AkkaRear.java
@@ -15,8 +15,8 @@ import com.spbsu.flamestream.runtime.edge.api.GimmeLastBatch;
 import com.spbsu.flamestream.runtime.utils.FlameConfig;
 import com.spbsu.flamestream.runtime.utils.akka.AwaitResolver;
 import com.spbsu.flamestream.runtime.utils.akka.LoggingActor;
-import javafx.collections.ObservableSet;
-import javafx.collections.SetChangeListener;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -137,15 +137,15 @@ public class AkkaRear implements Rear {
   }
 
   public static class Handles<T> {
-    private final ObservableSet<ActorRef> localMediators;
+    private final ObservableList<ActorRef> localMediators;
     private final List<Consumer<T>> sinks = new ArrayList<>();
 
-    Handles(ObservableSet<ActorRef> localMediators) {
+    Handles(ObservableList<ActorRef> localMediators) {
       this.localMediators = localMediators;
-      localMediators.addListener((SetChangeListener<ActorRef>) change -> {
-        if (change.wasAdded()) {
+      localMediators.addListener((ListChangeListener<ActorRef>) change -> {
+        for (ActorRef localMediator : change.getAddedSubList()) {
           for (Consumer<T> sink : sinks) {
-            change.getElementAdded().tell(sink, ActorRef.noSender());
+            localMediator.tell(sink, ActorRef.noSender());
           }
         }
       });

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/akka/AkkaRear.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/akka/AkkaRear.java
@@ -16,7 +16,7 @@ import com.spbsu.flamestream.runtime.utils.FlameConfig;
 import com.spbsu.flamestream.runtime.utils.akka.AwaitResolver;
 import com.spbsu.flamestream.runtime.utils.akka.LoggingActor;
 import javafx.collections.ListChangeListener;
-import javafx.collections.ObservableList;
+import org.reactfx.collection.LiveList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -137,10 +137,10 @@ public class AkkaRear implements Rear {
   }
 
   public static class Handles<T> {
-    private final ObservableList<ActorRef> localMediators;
+    private final LiveList<ActorRef> localMediators;
     private final List<Consumer<T>> sinks = new ArrayList<>();
 
-    Handles(ObservableList<ActorRef> localMediators) {
+    Handles(LiveList<ActorRef> localMediators) {
       this.localMediators = localMediators;
       localMediators.addListener((ListChangeListener<ActorRef>) change -> {
         for (ActorRef localMediator : change.getAddedSubList()) {

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/akka/AkkaRearType.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/akka/AkkaRearType.java
@@ -8,8 +8,8 @@ import akka.actor.RootActorPath;
 import com.spbsu.flamestream.runtime.FlameRuntime;
 import com.spbsu.flamestream.runtime.edge.EdgeContext;
 import javafx.collections.FXCollections;
-import javafx.collections.ObservableSet;
-import javafx.collections.SetChangeListener;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,17 +33,17 @@ public class AkkaRearType<T> implements FlameRuntime.RearType<AkkaRear, AkkaRear
   }
 
   @Override
-  public AkkaRear.Handles<T> handles(ObservableSet<EdgeContext> contexts) {
-    ObservableSet<ActorRef> localMediators =
-            FXCollections.observableSet(contexts.stream()
+  public AkkaRear.Handles<T> handles(ObservableList<EdgeContext> contexts) {
+    ObservableList<ActorRef> localMediators =
+            FXCollections.observableList(contexts.stream()
                     .map(this::localMediator)
-                    .collect(Collectors.toSet()));
-    contexts.addListener((SetChangeListener<EdgeContext>) change -> {
-      if (change.wasAdded()) {
-        localMediators.add(localMediator(change.getElementAdded()));
+                    .collect(Collectors.toList()));
+    contexts.addListener((ListChangeListener<EdgeContext>) change -> {
+      for (EdgeContext context : change.getAddedSubList()) {
+        localMediators.add(localMediator(context));
       }
     });
-    return new AkkaRear.Handles<>(FXCollections.unmodifiableObservableSet(localMediators));
+    return new AkkaRear.Handles<>(FXCollections.unmodifiableObservableList(localMediators));
   }
 
   private ActorRef localMediator(EdgeContext context) {

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/akka/AkkaRearType.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/akka/AkkaRearType.java
@@ -43,7 +43,7 @@ public class AkkaRearType<T> implements FlameRuntime.RearType<AkkaRear, AkkaRear
         localMediators.add(localMediator(change.getElementAdded()));
       }
     });
-    return new AkkaRear.Handles<>(localMediators);
+    return new AkkaRear.Handles<>(FXCollections.unmodifiableObservableSet(localMediators));
   }
 
   private ActorRef localMediator(EdgeContext context) {

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketRearType.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketRearType.java
@@ -2,7 +2,7 @@ package com.spbsu.flamestream.runtime.edge.socket;
 
 import com.spbsu.flamestream.runtime.FlameRuntime;
 import com.spbsu.flamestream.runtime.edge.EdgeContext;
-import javafx.collections.ObservableSet;
+import javafx.collections.ObservableList;
 
 /**
  * User: Artem
@@ -25,7 +25,7 @@ public class SocketRearType implements FlameRuntime.RearType<SocketRear, Void> {
   }
 
   @Override
-  public Void handles(ObservableSet<EdgeContext> context) {
+  public Void handles(ObservableList<EdgeContext> context) {
     return null;
   }
 

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketRearType.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketRearType.java
@@ -2,7 +2,7 @@ package com.spbsu.flamestream.runtime.edge.socket;
 
 import com.spbsu.flamestream.runtime.FlameRuntime;
 import com.spbsu.flamestream.runtime.edge.EdgeContext;
-import javafx.collections.ObservableList;
+import org.reactfx.collection.LiveList;
 
 /**
  * User: Artem
@@ -25,7 +25,7 @@ public class SocketRearType implements FlameRuntime.RearType<SocketRear, Void> {
   }
 
   @Override
-  public Void handles(ObservableList<EdgeContext> context) {
+  public Void handles(LiveList<EdgeContext> context) {
     return null;
   }
 

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketRearType.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketRearType.java
@@ -2,6 +2,7 @@ package com.spbsu.flamestream.runtime.edge.socket;
 
 import com.spbsu.flamestream.runtime.FlameRuntime;
 import com.spbsu.flamestream.runtime.edge.EdgeContext;
+import javafx.collections.ObservableSet;
 
 /**
  * User: Artem
@@ -24,7 +25,7 @@ public class SocketRearType implements FlameRuntime.RearType<SocketRear, Void> {
   }
 
   @Override
-  public Void handle(EdgeContext context) {
+  public Void handles(ObservableSet<EdgeContext> context) {
     return null;
   }
 

--- a/runtime/src/test/java/com/spbsu/flamestream/runtime/FlameUmbrella.java
+++ b/runtime/src/test/java/com/spbsu/flamestream/runtime/FlameUmbrella.java
@@ -24,6 +24,7 @@ import com.spbsu.flamestream.runtime.edge.api.AttachFront;
 import com.spbsu.flamestream.runtime.edge.api.AttachRear;
 import com.spbsu.flamestream.runtime.state.StateStorage;
 import com.spbsu.flamestream.runtime.utils.akka.LoggingActor;
+import javafx.collections.FXCollections;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
@@ -170,10 +171,9 @@ class FlameUmbrella extends LoggingActor {
               final AttachRear attach = new AttachRear(a.id, a.type.instance());
               toBeTold.add(attach);
               getContext().getChildren().forEach(n -> n.tell(attach, self()));
-              final List<Object> collect = paths.entrySet().stream()
-                      .map(node -> a.type.handle(new SystemEdgeContext(node.getValue(), node.getKey(), a.id)))
-                      .collect(Collectors.toList());
-              sender().tell(collect, self());
+              sender().tell(a.type.handles(FXCollections.observableSet(paths.entrySet().stream()
+                      .map(node -> new SystemEdgeContext(node.getValue(), node.getKey(), a.id))
+                      .collect(Collectors.toSet()))), self());
             })
             .build();
   }

--- a/runtime/src/test/java/com/spbsu/flamestream/runtime/FlameUmbrella.java
+++ b/runtime/src/test/java/com/spbsu/flamestream/runtime/FlameUmbrella.java
@@ -172,10 +172,10 @@ class FlameUmbrella extends LoggingActor {
               toBeTold.add(attach);
               getContext().getChildren().forEach(n -> n.tell(attach, self()));
               sender().tell(a.type.handles(
-                      FXCollections.unmodifiableObservableSet(FXCollections.observableSet(paths.entrySet()
+                      FXCollections.unmodifiableObservableList(FXCollections.observableList(paths.entrySet()
                               .stream()
                               .map(node -> new SystemEdgeContext(node.getValue(), node.getKey(), a.id))
-                              .collect(Collectors.toSet())))
+                              .collect(Collectors.toList())))
               ), self());
             })
             .build();

--- a/runtime/src/test/java/com/spbsu/flamestream/runtime/FlameUmbrella.java
+++ b/runtime/src/test/java/com/spbsu/flamestream/runtime/FlameUmbrella.java
@@ -171,9 +171,12 @@ class FlameUmbrella extends LoggingActor {
               final AttachRear attach = new AttachRear(a.id, a.type.instance());
               toBeTold.add(attach);
               getContext().getChildren().forEach(n -> n.tell(attach, self()));
-              sender().tell(a.type.handles(FXCollections.observableSet(paths.entrySet().stream()
-                      .map(node -> new SystemEdgeContext(node.getValue(), node.getKey(), a.id))
-                      .collect(Collectors.toSet()))), self());
+              sender().tell(a.type.handles(
+                      FXCollections.unmodifiableObservableSet(FXCollections.observableSet(paths.entrySet()
+                              .stream()
+                              .map(node -> new SystemEdgeContext(node.getValue(), node.getKey(), a.id))
+                              .collect(Collectors.toSet())))
+              ), self());
             })
             .build();
   }

--- a/runtime/src/test/java/com/spbsu/flamestream/runtime/FlameUmbrella.java
+++ b/runtime/src/test/java/com/spbsu/flamestream/runtime/FlameUmbrella.java
@@ -24,7 +24,7 @@ import com.spbsu.flamestream.runtime.edge.api.AttachFront;
 import com.spbsu.flamestream.runtime.edge.api.AttachRear;
 import com.spbsu.flamestream.runtime.state.StateStorage;
 import com.spbsu.flamestream.runtime.utils.akka.LoggingActor;
-import javafx.collections.FXCollections;
+import org.reactfx.collection.LiveArrayList;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
@@ -172,10 +172,10 @@ class FlameUmbrella extends LoggingActor {
               toBeTold.add(attach);
               getContext().getChildren().forEach(n -> n.tell(attach, self()));
               sender().tell(a.type.handles(
-                      FXCollections.unmodifiableObservableList(FXCollections.observableList(paths.entrySet()
+                      new LiveArrayList<>(paths.entrySet()
                               .stream()
                               .map(node -> new SystemEdgeContext(node.getValue(), node.getKey(), a.id))
-                              .collect(Collectors.toList())))
+                              .collect(Collectors.toList()))
               ), self());
             })
             .build();

--- a/runtime/src/test/java/com/spbsu/flamestream/runtime/LocalRuntime.java
+++ b/runtime/src/test/java/com/spbsu/flamestream/runtime/LocalRuntime.java
@@ -70,11 +70,11 @@ public class LocalRuntime implements FlameRuntime {
       }
 
       @Override
-      public <R extends Rear, H> Stream<H> attachRear(String id, RearType<R, H> type) {
+      public <R extends Rear, H> H attachRear(String id, RearType<R, H> type) {
         try {
           //noinspection unchecked
           return PatternsCS.ask(cluster, new FlameUmbrella.RearTypeWithId<>(id, type), FlameConfig.config.bigTimeout())
-                  .thenApply(a -> (List<H>) a).toCompletableFuture().get().stream();
+                  .thenApply(a -> (H) a).toCompletableFuture().get();
         } catch (InterruptedException | ExecutionException e) {
           throw new RuntimeException(e);
         }

--- a/runtime/src/test/java/com/spbsu/flamestream/runtime/acceptance/FilterAcceptanceTest.java
+++ b/runtime/src/test/java/com/spbsu/flamestream/runtime/acceptance/FilterAcceptanceTest.java
@@ -62,7 +62,7 @@ public final class FilterAcceptanceTest extends FlameAkkaSuite {
 
         final AwaitResultConsumer<Integer> consumer = new AwaitResultConsumer<>(streamSize);
         flame.attachRear("linerFilterRear", new AkkaRearType<>(runtime.system(), Integer.class))
-                .forEach(f -> f.addListener(consumer));
+                .addListener(consumer);
         applyDataToAllHandlesAsync(source, handles);
 
         consumer.await(5, TimeUnit.MINUTES);

--- a/runtime/src/test/java/com/spbsu/flamestream/runtime/acceptance/GroupingAcceptanceTest.java
+++ b/runtime/src/test/java/com/spbsu/flamestream/runtime/acceptance/GroupingAcceptanceTest.java
@@ -65,7 +65,7 @@ public final class GroupingAcceptanceTest extends FlameAkkaSuite {
                 .mapToInt(List::size)
                 .sum());
         flame.attachRear("groupingAcceptanceRear", new AkkaRearType<>(runtime.system(), List.class))
-                .forEach(r -> r.addListener(consumer::accept));
+                .addListener(consumer::accept);
         IntStream.range(0, parallelism).forEach(i -> applyDataToHandleAsync(source.get(i).stream(), handles.get(i)));
 
         consumer.await(5, TimeUnit.MINUTES);

--- a/runtime/src/test/java/com/spbsu/flamestream/runtime/invalidation/DoubleGroupingTest.java
+++ b/runtime/src/test/java/com/spbsu/flamestream/runtime/invalidation/DoubleGroupingTest.java
@@ -177,7 +177,7 @@ public class DoubleGroupingTest extends FlameStreamSuite {
       final List<Integer> expected = expected(source);
       final AwaitResultConsumer<Integer> consumer = new AwaitResultConsumer<>(expected.size());
       flame.attachRear("doubleGroupingRear", new AkkaRearType<>(runtime.system(), Integer.class))
-              .forEach(r -> r.addListener(consumer));
+              .addListener(consumer);
 
       final List<AkkaFront.FrontHandle<Integer>> handles = flame.attachFront(
               "doubleGroupingFront",

--- a/runtime/src/test/java/com/spbsu/flamestream/runtime/sum/SumTest.java
+++ b/runtime/src/test/java/com/spbsu/flamestream/runtime/sum/SumTest.java
@@ -90,7 +90,7 @@ public final class SumTest extends FlameAkkaSuite {
 
         final AwaitResultConsumer<Sum> consumer = new AwaitResultConsumer<>(source.stream().mapToInt(List::size).sum());
         flame.attachRear("sumRear", new AkkaRearType<>(runtime.system(), Sum.class))
-                .forEach(r -> r.addListener(consumer));
+                .addListener(consumer);
         IntStream.range(0, parallelism).forEach(i -> applyDataToHandleAsync(source.get(i).stream(), handles.get(i)));
 
         consumer.await(10, TimeUnit.MINUTES);
@@ -131,7 +131,7 @@ public final class SumTest extends FlameAkkaSuite {
 
         final AwaitResultConsumer<Sum> consumer = new AwaitResultConsumer<>(source.size());
         flame.attachRear("totalOrderRear", new AkkaRearType<>(runtime.system(), Sum.class))
-                .forEach(r -> r.addListener(consumer));
+                .addListener(consumer);
         source.forEach(sink);
         sink.eos();
 
@@ -161,7 +161,7 @@ public final class SumTest extends FlameAkkaSuite {
 
         final AwaitResultConsumer<Sum> consumer = new AwaitResultConsumer<>(source.size());
         flame.attachRear("totalOrderRear", new AkkaRearType<>(system, Sum.class))
-                .forEach(r -> r.addListener(consumer));
+                .addListener(consumer);
 
         final Set<Sum> expected = new HashSet<>();
         long currentSum = 0;


### PR DESCRIPTION
Первый шаг к тому, чтобы убрать `ClusterConfig#paths()`.