### PR TITLE
added if-idf example

### DIFF
--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/TfIdfGraph.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/TfIdfGraph.java
@@ -1,0 +1,169 @@
+package com.spbsu.flamestream.example.bl.tfidf;
+
+import com.spbsu.flamestream.core.DataItem;
+import com.spbsu.flamestream.core.Equalz;
+import com.spbsu.flamestream.core.Graph;
+import com.spbsu.flamestream.core.HashFunction;
+import com.spbsu.flamestream.core.graph.FlameMap;
+import com.spbsu.flamestream.core.graph.Grouping;
+import com.spbsu.flamestream.core.graph.Sink;
+import com.spbsu.flamestream.core.graph.Source;
+import com.spbsu.flamestream.example.bl.tfidf.model.TextDocument;
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.DocContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordDocContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.DocCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.WordCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.WordDocCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.DocEntry;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.WordDocEntry;
+import com.spbsu.flamestream.example.bl.tfidf.ops.entries.CountDocEntries;
+import com.spbsu.flamestream.example.bl.tfidf.ops.entries.CountWordDocEntries;
+import com.spbsu.flamestream.example.bl.tfidf.ops.entries.CountWordDocSingle;
+import com.spbsu.flamestream.example.bl.tfidf.ops.entries.CountWordEntries;
+import com.spbsu.flamestream.example.bl.tfidf.ops.filtering.DocContainerOrderingFilter;
+import com.spbsu.flamestream.example.bl.tfidf.ops.filtering.WordContainerOrderingFilter;
+import com.spbsu.flamestream.example.bl.tfidf.ops.filtering.WordDoc2WordFilter;
+import com.spbsu.flamestream.example.bl.tfidf.ops.filtering.WordDocContainerOrderingFilter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class TfIdfGraph implements Supplier<Graph> {
+    private final HashFunction wordHash = HashFunction.uniformHash(HashFunction.objectHash(WordContainer.class));
+    private final HashFunction docHash = HashFunction.uniformHash(HashFunction.objectHash(DocContainer.class));
+    private final HashFunction wordDocHash = HashFunction.uniformHash(HashFunction.objectHash(WordDocContainer.class));
+
+    @SuppressWarnings("Convert2Lambda")
+    private final Equalz equalz = new Equalz() {
+        @Override
+        public boolean test(DataItem o1, DataItem o2) {
+            return o1.payload(WordContainer.class).word().equals(o2.payload(WordContainer.class).word());
+        }
+    };
+
+    private final Equalz equalzWordDoc = new Equalz() {
+        @Override
+        public boolean test(DataItem o1, DataItem o2) {
+            return o1.payload(WordDocContainer.class).word().equals(o2.payload(WordDocContainer.class).word());
+        }
+    };
+
+    @SuppressWarnings("Convert2Lambda")
+    private final Equalz equalzDoc = new Equalz() {
+        @Override
+        public boolean test(DataItem o1, DataItem o2) {
+            return o1.payload(DocContainer.class).document().equals(o2.payload(DocContainer.class).document());
+        }
+    };
+
+    @Override
+    public Graph get() {
+        final Source source = new Source();
+
+        final Grouping<WordDocContainer> groupingWordDoc =
+                new Grouping<>(wordDocHash, equalzWordDoc, 2, WordDocContainer.class);
+        final Grouping<DocContainer> groupingDoc =
+                new Grouping<>(docHash, equalzDoc, 2, DocContainer.class);
+        final Grouping<WordDocContainer> groupingWordDocSingle =
+                new Grouping<>(wordDocHash, equalz, 2, WordDocContainer.class);
+        final Grouping<WordContainer> groupingIdf = new Grouping<>(wordHash, equalz, 2, WordContainer.class);
+
+        final FlameMap<TextDocument, WordDocEntry> splitterWordDoc = new FlameMap<>(new Function<TextDocument, Stream<WordDocEntry>>() {
+            private final Pattern pattern = Pattern.compile("\\s");
+
+            @Override
+            public Stream<WordDocEntry> apply(TextDocument s) {
+                return Arrays.stream(pattern.split(s.content()))
+                        .map(word -> new WordDocEntry(s.name(), word));
+            }
+        }, TextDocument.class);
+
+        final FlameMap<TextDocument, DocEntry> splitterDoc = new FlameMap<>(new Function<TextDocument, Stream<DocEntry>>() {
+            private final Pattern pattern = Pattern.compile("\\s");
+
+            @Override
+            public Stream<DocEntry> apply(TextDocument s) {
+                return Arrays.stream(pattern.split(s.content())).map(word -> new DocEntry(s.name()));
+            }
+        }, TextDocument.class);
+
+
+        final FlameMap<List<WordDocContainer>, List<WordDocContainer>> filterWordDoc = new FlameMap<>(
+                new WordDocContainerOrderingFilter(),
+                List.class
+        );
+        final FlameMap<List<DocContainer>, List<DocContainer>> filterDoc = new FlameMap<>(
+                new DocContainerOrderingFilter(),
+                List.class
+        );
+        final FlameMap<List<WordDocContainer>, List<WordDocContainer>> filterWordDocSingle = new FlameMap<>(
+                new WordDocContainerOrderingFilter(),
+                List.class
+        );
+        final FlameMap<WordDocCounter, WordContainer> filterWordDoc2Doc = new FlameMap<>(
+                new WordDoc2WordFilter(),
+                WordDocCounter.class
+        );
+        final FlameMap<List<WordContainer>, List<WordContainer>> filterIdf = new FlameMap<>(
+                new WordContainerOrderingFilter(),
+                List.class
+        );
+
+        final FlameMap<List<WordDocContainer>, WordDocCounter> counterWordDoc = new FlameMap<>(
+                new CountWordDocEntries(),
+                List.class
+        );
+        final FlameMap<List<DocContainer>, DocCounter> counterDoc = new FlameMap<>(
+                new CountDocEntries(),
+                List.class
+        );
+        final FlameMap<List<WordDocContainer>, WordDocCounter> counterWordDocSingle = new FlameMap<>(
+                new CountWordDocSingle(),
+                List.class
+        );
+        final FlameMap<List<WordContainer>, WordCounter> counterIdf = new FlameMap<>(
+                new CountWordEntries(),
+                List.class
+        );
+
+        final Sink sink = new Sink();
+        return new Graph.Builder()
+                .link(source, splitterWordDoc)
+                .link(source, splitterDoc)
+
+                .link(splitterWordDoc, groupingWordDoc)
+                .link(splitterDoc, groupingDoc)
+                .link(splitterWordDoc, groupingWordDocSingle)
+
+                .link(groupingWordDoc, filterWordDoc)
+                .link(groupingWordDocSingle, filterWordDocSingle)
+                .link(groupingDoc, filterDoc)
+
+                .link(filterWordDoc, counterWordDoc)
+                .link(filterDoc, counterDoc)
+                .link(filterWordDocSingle, counterWordDocSingle)
+
+                .link(counterWordDoc, sink)
+                .link(counterDoc, sink)
+                .link(counterWordDocSingle, filterWordDoc2Doc)
+
+                .link(counterWordDoc, groupingWordDoc)
+                .link(counterDoc, groupingDoc)
+                .link(counterWordDocSingle, groupingWordDocSingle)
+
+                .link(filterWordDoc2Doc, groupingIdf)
+                .link(groupingIdf, filterIdf)
+                .link(filterIdf, counterIdf)
+                .link(counterIdf, groupingIdf)
+                .link(counterIdf, sink)
+
+                .colocate(source, splitterWordDoc)
+                .colocate(groupingWordDoc, filterWordDoc, counterWordDoc, sink)
+                .build(source, sink);
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/TfIdfGraph.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/TfIdfGraph.java
@@ -46,6 +46,7 @@ public class TfIdfGraph implements Supplier<Graph> {
         }
     };
 
+    @SuppressWarnings("Convert2Lambda")
     private final Equalz equalzWordDoc = new Equalz() {
         @Override
         public boolean test(DataItem o1, DataItem o2) {

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/TextDocument.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/TextDocument.java
@@ -1,0 +1,43 @@
+package com.spbsu.flamestream.example.bl.tfidf.model;
+
+import java.util.Objects;
+
+public class TextDocument {
+    private final String name;
+    private final String content;
+
+    public TextDocument(String name, String content) {
+        this.name = name;
+        this.content = content;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String content() {
+        return content;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s: >%s<", name, content);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final TextDocument otherText = (TextDocument) o;
+        return Objects.equals(name, otherText.name) && Objects.equals(content, otherText.content);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name.hashCode(), content.hashCode());
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/containers/DocContainer.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/containers/DocContainer.java
@@ -1,0 +1,5 @@
+package com.spbsu.flamestream.example.bl.tfidf.model.containers;
+
+public interface DocContainer {
+    String document();
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/containers/WordContainer.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/containers/WordContainer.java
@@ -1,0 +1,5 @@
+package com.spbsu.flamestream.example.bl.tfidf.model.containers;
+
+public interface WordContainer {
+    String word();
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/containers/WordDocContainer.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/containers/WordDocContainer.java
@@ -1,0 +1,4 @@
+package com.spbsu.flamestream.example.bl.tfidf.model.containers;
+
+public interface WordDocContainer extends DocContainer, WordContainer {
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/counters/DocCounter.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/counters/DocCounter.java
@@ -1,0 +1,50 @@
+package com.spbsu.flamestream.example.bl.tfidf.model.counters;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.DocEntry;
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.DocContainer;
+
+public class DocCounter implements DocContainer {
+    private final DocEntry docEntry;
+    private final int count;
+
+    public DocCounter(DocEntry docEntry, int count) {
+        this.docEntry = docEntry;
+        this.count = count;
+    }
+
+    @Override
+    public String document() {
+        return docEntry.document();
+    }
+
+    public DocEntry docEntry() {
+        return docEntry;
+    }
+
+    public int count() {
+        return count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final DocCounter that = (DocCounter) o;
+        return count == that.count && document().equals(that.document());
+    }
+
+    @Override
+    public int hashCode() {
+        return docEntry.document().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("DocCounter %s: %d", docEntry, count);
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/counters/WordCounter.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/counters/WordCounter.java
@@ -1,0 +1,50 @@
+package com.spbsu.flamestream.example.bl.tfidf.model.counters;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.WordEntry;
+
+public class WordCounter implements WordContainer {
+    private final WordEntry wordEntry;
+    private final int count;
+
+    public WordCounter(WordEntry wordEntry, int count) {
+        this.wordEntry = wordEntry;
+        this.count = count;
+    }
+
+    @Override
+    public String word() {
+        return wordEntry.word();
+    }
+
+    public WordEntry wordEntry() {
+        return wordEntry;
+    }
+
+    public int count() {
+        return count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final WordCounter that = (WordCounter) o;
+        return count == that.count && wordEntry.equals(that.wordEntry);
+    }
+
+    @Override
+    public int hashCode() {
+        return wordEntry.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s: %d", wordEntry, count);
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/counters/WordDocCounter.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/counters/WordDocCounter.java
@@ -1,0 +1,55 @@
+package com.spbsu.flamestream.example.bl.tfidf.model.counters;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordDocContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.WordDocEntry;
+
+public class WordDocCounter implements WordDocContainer {
+    private final WordDocEntry wordDocEntry;
+    private final int count;
+
+    public WordDocCounter(WordDocEntry wordDocEntry, int count) {
+        this.wordDocEntry = wordDocEntry;
+        this.count = count;
+    }
+
+    @Override
+    public String  word() {
+        return wordDocEntry.word();
+    }
+
+    @Override
+    public String document() {
+        return wordDocEntry.document();
+    }
+
+    public WordDocEntry  wordDocEntry() {
+        return wordDocEntry;
+    }
+
+    public int count() {
+        return count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final WordDocCounter that = (WordDocCounter) o;
+        return count == that.count && wordDocEntry.equals(that.wordDocEntry);
+    }
+
+    @Override
+    public int hashCode() {
+        return wordDocEntry.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s: %d", wordDocEntry, count);
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/entries/DocEntry.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/entries/DocEntry.java
@@ -1,0 +1,39 @@
+package com.spbsu.flamestream.example.bl.tfidf.model.entries;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.DocContainer;
+import java.util.Objects;
+
+public class DocEntry implements DocContainer {
+    private final String document;
+
+    public DocEntry(String document) {
+        this.document = document;
+    }
+
+    @Override
+    public String document() {
+        return document;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("DocEntry >%s<", document);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DocEntry docEntry = (DocEntry) o;
+        return Objects.equals(document, docEntry.document());
+    }
+
+    @Override
+    public int hashCode() {
+        return document.hashCode();
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/entries/WordDocEntry.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/entries/WordDocEntry.java
@@ -1,0 +1,47 @@
+package com.spbsu.flamestream.example.bl.tfidf.model.entries;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordDocContainer;
+
+import java.util.Objects;
+
+public class WordDocEntry implements WordDocContainer {
+    private final String word;
+    private final String document;
+
+    public WordDocEntry(String document, String word) {
+        this.document = document;
+        this.word = word;
+    }
+
+    @Override
+    public String document() {
+        return document;
+    }
+
+    @Override
+    public String word() {
+        return word;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s: >%s<", document, word);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final WordDocEntry wordEntry = (WordDocEntry) o;
+        return Objects.equals(word, wordEntry.word) && Objects.equals(document, wordEntry.document());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(word, document);
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/entries/WordEntry.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/model/entries/WordEntry.java
@@ -1,0 +1,40 @@
+package com.spbsu.flamestream.example.bl.tfidf.model.entries;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordContainer;
+
+import java.util.Objects;
+
+public class WordEntry implements WordContainer {
+    private final String word;
+
+    public WordEntry(String word) {
+        this.word = word;
+    }
+
+    @Override
+    public String word() {
+        return word;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(">%s<", word);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final WordEntry wordEntry = (WordEntry) o;
+        return Objects.equals(word, wordEntry.word);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(word);
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/entries/CountDocEntries.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/entries/CountDocEntries.java
@@ -1,0 +1,23 @@
+package com.spbsu.flamestream.example.bl.tfidf.ops.entries;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.DocContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.DocCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.DocEntry;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+
+public class CountDocEntries implements Function<List<DocContainer>, Stream<DocCounter>> {
+    @Override
+    public Stream<DocCounter> apply(List<DocContainer> docContainers) {
+        if (docContainers.size() == 1) {
+            final DocEntry docEntry = (DocEntry) docContainers.get(0);
+            return Stream.of(new DocCounter(docEntry, 1));
+        } else {
+            final DocCounter counter = (DocCounter) docContainers.get(0);
+            return Stream.of(new DocCounter(counter.docEntry(), counter.count() + 1));
+        }
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/entries/CountWordDocEntries.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/entries/CountWordDocEntries.java
@@ -1,0 +1,22 @@
+package com.spbsu.flamestream.example.bl.tfidf.ops.entries;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordDocContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.WordDocCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.WordDocEntry;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class CountWordDocEntries implements Function<List<WordDocContainer>, Stream<WordDocCounter>> {
+    @Override
+    public Stream<WordDocCounter> apply(List<WordDocContainer> wordDocContainers) {
+        if (wordDocContainers.size() == 1) {
+            final WordDocEntry wordDocEntry = (WordDocEntry) wordDocContainers.get(0);
+            return Stream.of(new WordDocCounter(wordDocEntry, 1));
+        } else {
+            final WordDocCounter counter = (WordDocCounter) wordDocContainers.get(0);
+            return Stream.of(new WordDocCounter(counter.wordDocEntry(), counter.count() + 1));
+        }
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/entries/CountWordDocSingle.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/entries/CountWordDocSingle.java
@@ -1,0 +1,22 @@
+package com.spbsu.flamestream.example.bl.tfidf.ops.entries;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordDocContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.WordDocCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.WordDocEntry;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class CountWordDocSingle implements Function<List<WordDocContainer>, Stream<WordDocCounter>> {
+    @Override
+    public Stream<WordDocCounter> apply(List<WordDocContainer> wordDocContainers) {
+        if (wordDocContainers.size() == 1) {
+            final WordDocEntry wordDocEntry = (WordDocEntry) wordDocContainers.get(0);
+            return Stream.of(new WordDocCounter(wordDocEntry, 1));
+        } else {
+            final WordDocCounter counter = (WordDocCounter) wordDocContainers.get(0);
+            return Stream.of(new WordDocCounter(counter.wordDocEntry(), 0));
+        }
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/entries/CountWordEntries.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/entries/CountWordEntries.java
@@ -1,0 +1,22 @@
+package com.spbsu.flamestream.example.bl.tfidf.ops.entries;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.WordCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.WordEntry;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class CountWordEntries implements Function<List<WordContainer>, Stream<WordCounter>> {
+    @Override
+    public Stream<WordCounter> apply(List<WordContainer> wordContainers) {
+        if (wordContainers.size() == 1) {
+            final WordEntry wordEntry = (WordEntry) wordContainers.get(0);
+            return Stream.of(new WordCounter(wordEntry, 1));
+        } else {
+            final WordCounter counter = (WordCounter) wordContainers.get(0);
+            return Stream.of(new WordCounter(counter.wordEntry(), counter.count() + 1));
+        }
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/filtering/DocContainerOrderingFilter.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/filtering/DocContainerOrderingFilter.java
@@ -1,0 +1,30 @@
+package com.spbsu.flamestream.example.bl.tfidf.ops.filtering;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.DocContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.DocCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.DocEntry;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class DocContainerOrderingFilter implements Function<List<DocContainer>, Stream<List<DocContainer>>> {
+
+    @Override
+    public Stream<List<DocContainer>> apply(List<DocContainer> docContainers) {
+        if (docContainers.size() > 2) {
+            throw new IllegalStateException("Group size should be <= 2");
+        }
+
+        if (docContainers.size() == 1 && !(docContainers.get(0) instanceof DocEntry)) {
+            throw new IllegalStateException("The only element in group should be DocEntry");
+        }
+
+        if (docContainers.size() == 1 || (docContainers.get(0) instanceof DocCounter
+                && docContainers.get(1) instanceof DocEntry)) {
+            return Stream.of(docContainers);
+        } else {
+            return Stream.empty();
+        }
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/filtering/WordContainerOrderingFilter.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/filtering/WordContainerOrderingFilter.java
@@ -1,0 +1,30 @@
+package com.spbsu.flamestream.example.bl.tfidf.ops.filtering;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.WordCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.WordEntry;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class WordContainerOrderingFilter implements Function<List<WordContainer>, Stream<List<WordContainer>>> {
+
+    @Override
+    public Stream<List<WordContainer>> apply(List<WordContainer> wordContainers) {
+        if (wordContainers.size() > 2) {
+            throw new IllegalStateException("Group size should be <= 2");
+        }
+
+        if (wordContainers.size() == 1 && !(wordContainers.get(0) instanceof WordEntry)) {
+            throw new IllegalStateException("The only element in group should be WordEntry");
+        }
+
+        if (wordContainers.size() == 1 || (wordContainers.get(0) instanceof WordCounter
+                && wordContainers.get(1) instanceof WordEntry)) {
+            return Stream.of(wordContainers);
+        } else {
+            return Stream.empty();
+        }
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/filtering/WordDoc2WordFilter.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/filtering/WordDoc2WordFilter.java
@@ -1,0 +1,19 @@
+package com.spbsu.flamestream.example.bl.tfidf.ops.filtering;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.WordDocCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.WordEntry;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class WordDoc2WordFilter implements Function<WordDocCounter, Stream<WordContainer>> {
+    @Override
+    public Stream<WordContainer> apply(WordDocCounter wordDocCounter) {
+        if (wordDocCounter.count() == 0) {
+            return Stream.empty();
+        } else {
+            return Stream.of(new WordEntry(wordDocCounter.word()));
+        }
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/filtering/WordDocContainerOrderingFilter.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/filtering/WordDocContainerOrderingFilter.java
@@ -1,0 +1,30 @@
+package com.spbsu.flamestream.example.bl.tfidf.ops.filtering;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordDocContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.WordDocCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.WordDocEntry;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class WordDocContainerOrderingFilter implements Function<List<WordDocContainer>, Stream<List<WordDocContainer>>> {
+
+    @Override
+    public Stream<List<WordDocContainer>> apply(List<WordDocContainer> wordDocContainers) {
+        if (wordDocContainers.size() > 2) {
+            throw new IllegalStateException("Group size should be <= 2");
+        }
+
+        if (wordDocContainers.size() == 1 && !(wordDocContainers.get(0) instanceof WordDocEntry)) {
+            throw new IllegalStateException("The only element in group should be WordEntry");
+        }
+
+        if (wordDocContainers.size() == 1 || (wordDocContainers.get(0) instanceof WordDocCounter
+                && wordDocContainers.get(1) instanceof WordDocEntry)) {
+            return Stream.of(wordDocContainers);
+        } else {
+            return Stream.empty();
+        }
+    }
+}

--- a/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/filtering/WordDocContainerSingleFilter.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/bl/tfidf/ops/filtering/WordDocContainerSingleFilter.java
@@ -1,0 +1,28 @@
+package com.spbsu.flamestream.example.bl.tfidf.ops.filtering;
+
+import com.spbsu.flamestream.example.bl.tfidf.model.containers.WordDocContainer;
+import com.spbsu.flamestream.example.bl.tfidf.model.entries.WordDocEntry;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class WordDocContainerSingleFilter implements Function<List<WordDocContainer>, Stream<List<WordDocContainer>>> {
+
+    @Override
+    public Stream<List<WordDocContainer>> apply(List<WordDocContainer> wordDocContainers) {
+        if (wordDocContainers.size() > 2) {
+            throw new IllegalStateException("Group size should be <= 2");
+        }
+
+        if (wordDocContainers.size() == 1 && !(wordDocContainers.get(0) instanceof WordDocEntry)) {
+            throw new IllegalStateException("The only element in group should be WordEntry");
+        }
+
+        if (wordDocContainers.size() == 1) {
+            return Stream.of(wordDocContainers);
+        } else {
+            return Stream.empty();
+        }
+    }
+}

--- a/examples/src/test/java/com/spbsu/flamestream/example/bl/tfidf/TfIdfTest.java
+++ b/examples/src/test/java/com/spbsu/flamestream/example/bl/tfidf/TfIdfTest.java
@@ -1,0 +1,157 @@
+package com.spbsu.flamestream.example.bl.tfidf;
+
+import akka.japi.Pair;
+import com.spbsu.flamestream.example.bl.tfidf.model.TextDocument;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.DocCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.WordCounter;
+import com.spbsu.flamestream.example.bl.tfidf.model.counters.WordDocCounter;
+import com.spbsu.flamestream.runtime.FlameRuntime;
+import com.spbsu.flamestream.runtime.LocalRuntime;
+import com.spbsu.flamestream.runtime.acceptance.FlameAkkaSuite;
+import com.spbsu.flamestream.runtime.edge.akka.AkkaFront;
+import com.spbsu.flamestream.runtime.edge.akka.AkkaFrontType;
+import com.spbsu.flamestream.runtime.edge.akka.AkkaRearType;
+import com.spbsu.flamestream.runtime.utils.AwaitResultConsumer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.*;
+
+/**
+ * User: Artem
+ * Date: 19.12.2017
+ */
+
+public class TfIdfTest extends FlameAkkaSuite {
+  private static class Tale {
+    String name;
+    String words[];
+
+    Tale(String name, String words[]) {
+      this.name = name;
+      this.words = words;
+    }
+  }
+
+  private static Tale[] tales = {
+          new Tale("Repka",
+            new String[]{"posadil", "ded", "repku", "i", "vysrosla", "repka", "bolshaya-prebolshaya"}),
+          new Tale("Fisher and fish",
+                    new String[]{"zhili-byli", "starik", "so", "staruhoy", "u", "samogo", "sinego", "morya"}),
+  };
+
+ private Stream<Pair<String, String>> wordDocPairs(Queue<TextDocument> queue) {
+     final Pattern pattern = Pattern.compile("\\s");
+     return queue.stream()
+             .flatMap(doc -> Arrays.stream(pattern.split(doc.content()))
+                     .map(word -> new Pair<>(word, doc.name())));
+ }
+
+ private int sumValues(Map<String, Integer> map) {
+     return map.values().stream().reduce(Integer::sum).orElse(0);
+ }
+
+ private void testTales(int streamSize, int lineSize, List<Tale> tales) throws InterruptedException {
+      try (final LocalRuntime runtime = new LocalRuntime.Builder().maxElementsInGraph(2)
+              .millisBetweenCommits(500)
+              .build()) {
+          final FlameRuntime.Flame flame = runtime.run(new TfIdfGraph().get());
+          {
+              final Queue<TextDocument> input = Stream.generate(() ->
+                      tales.stream().map(tale -> {
+                          String content = new Random().ints(lineSize, 0, tale.words.length)
+                                  .mapToObj(i -> tale.words[i])
+                                  .collect(joining(" "));
+                          return new TextDocument(tale.name, content); }))
+                      .limit(streamSize).flatMap(Function.identity())
+                      .collect(Collectors.toCollection(ConcurrentLinkedQueue::new));
+
+              final Pattern pattern = Pattern.compile("\\s");
+
+              final Map<String, Map<String, Integer>> expectedWordDoc = wordDocPairs(input)
+                      .collect(groupingBy(Pair::first, mapping(Pair::second, toMap(Function.identity(), o -> 1, Integer::sum))));
+              final Map<String, Integer> expectedDoc = input.stream()
+                      .flatMap(doc -> Arrays.stream(pattern.split(doc.content()))
+                              .map(word -> new Pair<>(doc.name(), word)))
+                      .collect(toMap(Pair::first, o -> 1, Integer::sum));
+              final Map<String, Integer> expectedIdf = wordDocPairs(input)
+                      .collect(groupingBy(Pair::first, collectingAndThen(toSet(), Set::size)));
+
+              int nExpected = Stream.concat(expectedWordDoc.values().stream(), Stream.of(expectedDoc, expectedIdf)).map(e -> sumValues(e)).reduce(Integer::sum).orElse(0);
+
+              final AwaitResultConsumer<Object> awaitConsumer = new AwaitResultConsumer<>(nExpected);
+              flame.attachRear("tfidfRear", new AkkaRearType<>(runtime.system(), Object.class))
+                      .forEach(r -> r.addListener(awaitConsumer));
+              final List<AkkaFront.FrontHandle<TextDocument>> handles = flame
+                      .attachFront("tfidfFront", new AkkaFrontType<TextDocument>(runtime.system()))
+                      .collect(toList());
+              applyDataToAllHandlesAsync(input, handles);
+              awaitConsumer.await(5, TimeUnit.MINUTES);
+
+              final Map<String, Integer> actualDoc = new HashMap<>();
+              final Map<String, Integer> actualIdf = new HashMap<>();
+              final Map<Pair<String, String>, Integer> actualPairs = new HashMap<>();
+              awaitConsumer.result().forEach(o -> {
+                  if (o instanceof WordDocCounter){
+                      final WordDocCounter wordDocContainer = (WordDocCounter) o;
+                      Pair<String, String> p = new Pair(wordDocContainer.word(), wordDocContainer.document());
+                      actualPairs.putIfAbsent(p, 0);
+                      actualPairs.computeIfPresent(p, (uid, old) -> Math.max(wordDocContainer.count(), old));
+                  } else if (o instanceof DocCounter) {
+                      final DocCounter docContainer = (DocCounter) o;
+                      actualDoc.putIfAbsent(docContainer.document(), 0);
+                      actualDoc.computeIfPresent(docContainer.document(), (uid, old) -> Math.max(docContainer.count(), old));
+                  } else if (o instanceof WordCounter) {
+                      final WordCounter wordContainer = (WordCounter) o;
+                      actualIdf.putIfAbsent(wordContainer.word(), 0);
+                      actualIdf.computeIfPresent(wordContainer.word(), (uid, old) -> Math.max(wordContainer.count(), old));
+                  } else {
+                      System.out.println("unexpected: " + o);
+                  }
+              });
+
+              final Map<String, Map<String, Integer>> actualWordDoc = actualPairs.entrySet().stream()
+                      .collect(groupingBy(v -> v.getKey().first(),
+                              toMap(v -> v.getKey().second(), v -> v.getValue())));
+
+              Assert.assertEquals(actualWordDoc, expectedWordDoc);
+              Assert.assertEquals(actualDoc, expectedDoc);
+              Assert.assertEquals(actualIdf, expectedIdf);
+            }
+        }
+    }
+
+  private void testSingleTale(int streamSize, int lineSize, Tale tale) throws InterruptedException {
+      testTales(2, 10, Arrays.asList(tale));
+  }
+
+
+  @Test(invocationCount = 1)
+  public void singleDocumentTest() throws InterruptedException {
+    for (Tale tale: tales) {
+      testSingleTale(1, 50, tale);
+    }
+  }
+
+
+  public void singleDocumentManyTimesTest() throws InterruptedException {
+    for (Tale tale: tales) {
+      testSingleTale(100, 50, tale);
+    }
+  }
+
+  @Test(invocationCount = 1)
+  public void twoIntersectingDocumentsTest() throws InterruptedException {
+      Tale tale1 = new Tale("t1", new String[]{"word1", "word2"});
+      Tale tale2 = new Tale("t2", new String[]{"word2", "word3"});
+      testTales(2, 10, Arrays.asList(tale1, tale2));
+  }
+}

--- a/examples/src/test/java/com/spbsu/flamestream/example/bl/tfidf/TfIdfTest.java
+++ b/examples/src/test/java/com/spbsu/flamestream/example/bl/tfidf/TfIdfTest.java
@@ -42,116 +42,129 @@ public class TfIdfTest extends FlameAkkaSuite {
   }
 
   private static Tale[] tales = {
-          new Tale("Repka",
-            new String[]{"posadil", "ded", "repku", "i", "vysrosla", "repka", "bolshaya-prebolshaya"}),
-          new Tale("Fisher and fish",
-                    new String[]{"zhili-byli", "starik", "so", "staruhoy", "u", "samogo", "sinego", "morya"}),
-  };
+          new Tale(
+                  "Repka",
+                  new String[]{"posadil", "ded", "repku", "i", "vysrosla", "repka", "bolshaya-prebolshaya"}
+          ),
+          new Tale(
+                  "Fisher and fish",
+                  new String[]{"zhili-byli", "starik", "so", "staruhoy", "u", "samogo", "sinego", "morya"}
+          ),
+          };
 
- private Stream<Pair<String, String>> wordDocPairs(Queue<TextDocument> queue) {
-     final Pattern pattern = Pattern.compile("\\s");
-     return queue.stream()
-             .flatMap(doc -> Arrays.stream(pattern.split(doc.content()))
-                     .map(word -> new Pair<>(word, doc.name())));
- }
+  private Stream<Pair<String, String>> wordDocPairs(Queue<TextDocument> queue) {
+    final Pattern pattern = Pattern.compile("\\s");
+    return queue.stream()
+            .flatMap(doc -> Arrays.stream(pattern.split(doc.content()))
+                    .map(word -> new Pair<>(word, doc.name())));
+  }
 
- private int sumValues(Map<String, Integer> map) {
-     return map.values().stream().reduce(Integer::sum).orElse(0);
- }
+  private int sumValues(Map<String, Integer> map) {
+    return map.values().stream().reduce(Integer::sum).orElse(0);
+  }
 
- private void testTales(int streamSize, int lineSize, List<Tale> tales) throws InterruptedException {
-      try (final LocalRuntime runtime = new LocalRuntime.Builder().maxElementsInGraph(2)
-              .millisBetweenCommits(500)
-              .build()) {
-          final FlameRuntime.Flame flame = runtime.run(new TfIdfGraph().get());
-          {
-              final Queue<TextDocument> input = Stream.generate(() ->
-                      tales.stream().map(tale -> {
-                          String content = new Random().ints(lineSize, 0, tale.words.length)
-                                  .mapToObj(i -> tale.words[i])
-                                  .collect(joining(" "));
-                          return new TextDocument(tale.name, content); }))
-                      .limit(streamSize).flatMap(Function.identity())
-                      .collect(Collectors.toCollection(ConcurrentLinkedQueue::new));
+  private void testTales(int streamSize, int lineSize, List<Tale> tales) throws InterruptedException {
+    try (final LocalRuntime runtime = new LocalRuntime.Builder().maxElementsInGraph(2)
+            .millisBetweenCommits(500)
+            .build()) {
+      final FlameRuntime.Flame flame = runtime.run(new TfIdfGraph().get());
+      {
+        final Queue<TextDocument> input = Stream.generate(() ->
+                tales.stream().map(tale -> {
+                  String content = new Random().ints(lineSize, 0, tale.words.length)
+                          .mapToObj(i -> tale.words[i])
+                          .collect(joining(" "));
+                  return new TextDocument(tale.name, content);
+                }))
+                .limit(streamSize).flatMap(Function.identity())
+                .collect(Collectors.toCollection(ConcurrentLinkedQueue::new));
 
-              final Pattern pattern = Pattern.compile("\\s");
+        final Pattern pattern = Pattern.compile("\\s");
 
-              final Map<String, Map<String, Integer>> expectedWordDoc = wordDocPairs(input)
-                      .collect(groupingBy(Pair::first, mapping(Pair::second, toMap(Function.identity(), o -> 1, Integer::sum))));
-              final Map<String, Integer> expectedDoc = input.stream()
-                      .flatMap(doc -> Arrays.stream(pattern.split(doc.content()))
-                              .map(word -> new Pair<>(doc.name(), word)))
-                      .collect(toMap(Pair::first, o -> 1, Integer::sum));
-              final Map<String, Integer> expectedIdf = wordDocPairs(input)
-                      .collect(groupingBy(Pair::first, collectingAndThen(toSet(), Set::size)));
+        final Map<String, Map<String, Integer>> expectedWordDoc = wordDocPairs(input)
+                .collect(groupingBy(
+                        Pair::first,
+                        mapping(Pair::second, toMap(Function.identity(), o -> 1, Integer::sum))
+                ));
+        final Map<String, Integer> expectedDoc = input.stream()
+                .flatMap(doc -> Arrays.stream(pattern.split(doc.content()))
+                        .map(word -> new Pair<>(doc.name(), word)))
+                .collect(toMap(Pair::first, o -> 1, Integer::sum));
+        final Map<String, Integer> expectedIdf = wordDocPairs(input)
+                .collect(groupingBy(Pair::first, collectingAndThen(toSet(), Set::size)));
 
-              int nExpected = Stream.concat(expectedWordDoc.values().stream(), Stream.of(expectedDoc, expectedIdf)).map(e -> sumValues(e)).reduce(Integer::sum).orElse(0);
+        int nExpected = Stream.concat(expectedWordDoc.values().stream(), Stream.of(expectedDoc, expectedIdf))
+                .map(e -> sumValues(e))
+                .reduce(Integer::sum)
+                .orElse(0);
 
-              final AwaitResultConsumer<Object> awaitConsumer = new AwaitResultConsumer<>(nExpected);
-              flame.attachRear("tfidfRear", new AkkaRearType<>(runtime.system(), Object.class))
-                      .forEach(r -> r.addListener(awaitConsumer));
-              final List<AkkaFront.FrontHandle<TextDocument>> handles = flame
-                      .attachFront("tfidfFront", new AkkaFrontType<TextDocument>(runtime.system()))
-                      .collect(toList());
-              applyDataToAllHandlesAsync(input, handles);
-              awaitConsumer.await(5, TimeUnit.MINUTES);
+        final AwaitResultConsumer<Object> awaitConsumer = new AwaitResultConsumer<>(nExpected);
+        flame.attachRear("tfidfRear", new AkkaRearType<>(runtime.system(), Object.class))
+                .forEach(r -> r.addListener(awaitConsumer));
+        final List<AkkaFront.FrontHandle<TextDocument>> handles = flame
+                .attachFront("tfidfFront", new AkkaFrontType<TextDocument>(runtime.system()))
+                .collect(toList());
+        applyDataToAllHandlesAsync(input, handles);
+        awaitConsumer.await(5, TimeUnit.MINUTES);
 
-              final Map<String, Integer> actualDoc = new HashMap<>();
-              final Map<String, Integer> actualIdf = new HashMap<>();
-              final Map<Pair<String, String>, Integer> actualPairs = new HashMap<>();
-              awaitConsumer.result().forEach(o -> {
-                  if (o instanceof WordDocCounter){
-                      final WordDocCounter wordDocContainer = (WordDocCounter) o;
-                      Pair<String, String> p = new Pair(wordDocContainer.word(), wordDocContainer.document());
-                      actualPairs.putIfAbsent(p, 0);
-                      actualPairs.computeIfPresent(p, (uid, old) -> Math.max(wordDocContainer.count(), old));
-                  } else if (o instanceof DocCounter) {
-                      final DocCounter docContainer = (DocCounter) o;
-                      actualDoc.putIfAbsent(docContainer.document(), 0);
-                      actualDoc.computeIfPresent(docContainer.document(), (uid, old) -> Math.max(docContainer.count(), old));
-                  } else if (o instanceof WordCounter) {
-                      final WordCounter wordContainer = (WordCounter) o;
-                      actualIdf.putIfAbsent(wordContainer.word(), 0);
-                      actualIdf.computeIfPresent(wordContainer.word(), (uid, old) -> Math.max(wordContainer.count(), old));
-                  } else {
-                      System.out.println("unexpected: " + o);
-                  }
-              });
+        final Map<String, Integer> actualDoc = new HashMap<>();
+        final Map<String, Integer> actualIdf = new HashMap<>();
+        final Map<Pair<String, String>, Integer> actualPairs = new HashMap<>();
+        awaitConsumer.result().forEach(o -> {
+          if (o instanceof WordDocCounter) {
+            final WordDocCounter wordDocContainer = (WordDocCounter) o;
+            Pair<String, String> p = new Pair(wordDocContainer.word(), wordDocContainer.document());
+            actualPairs.putIfAbsent(p, 0);
+            actualPairs.computeIfPresent(p, (uid, old) -> Math.max(wordDocContainer.count(), old));
+          } else if (o instanceof DocCounter) {
+            final DocCounter docContainer = (DocCounter) o;
+            actualDoc.putIfAbsent(docContainer.document(), 0);
+            actualDoc.computeIfPresent(docContainer.document(), (uid, old) -> Math.max(docContainer.count(), old));
+          } else if (o instanceof WordCounter) {
+            final WordCounter wordContainer = (WordCounter) o;
+            actualIdf.putIfAbsent(wordContainer.word(), 0);
+            actualIdf.computeIfPresent(wordContainer.word(), (uid, old) -> Math.max(wordContainer.count(), old));
+          } else {
+            System.out.println("unexpected: " + o);
+          }
+        });
 
-              final Map<String, Map<String, Integer>> actualWordDoc = actualPairs.entrySet().stream()
-                      .collect(groupingBy(v -> v.getKey().first(),
-                              toMap(v -> v.getKey().second(), v -> v.getValue())));
+        final Map<String, Map<String, Integer>> actualWordDoc = actualPairs.entrySet().stream()
+                .collect(groupingBy(
+                        v -> v.getKey().first(),
+                        toMap(v -> v.getKey().second(), v -> v.getValue())
+                ));
 
-              Assert.assertEquals(actualWordDoc, expectedWordDoc);
-              Assert.assertEquals(actualDoc, expectedDoc);
-              Assert.assertEquals(actualIdf, expectedIdf);
-            }
-        }
+        Assert.assertEquals(actualWordDoc, expectedWordDoc);
+        Assert.assertEquals(actualDoc, expectedDoc);
+        Assert.assertEquals(actualIdf, expectedIdf);
+      }
     }
+  }
 
   private void testSingleTale(int streamSize, int lineSize, Tale tale) throws InterruptedException {
-      testTales(2, 10, Arrays.asList(tale));
+    testTales(2, 10, Arrays.asList(tale));
   }
 
 
-  @Test(invocationCount = 1)
+  @Test(invocationCount = 100)
   public void singleDocumentTest() throws InterruptedException {
-    for (Tale tale: tales) {
+    for (Tale tale : tales) {
       testSingleTale(1, 50, tale);
     }
   }
 
-
+  @Test(invocationCount = 100)
   public void singleDocumentManyTimesTest() throws InterruptedException {
-    for (Tale tale: tales) {
+    for (Tale tale : tales) {
       testSingleTale(100, 50, tale);
     }
   }
 
-  @Test(invocationCount = 1)
+  @Test(invocationCount = 100)
   public void twoIntersectingDocumentsTest() throws InterruptedException {
-      Tale tale1 = new Tale("t1", new String[]{"word1", "word2"});
-      Tale tale2 = new Tale("t2", new String[]{"word2", "word3"});
-      testTales(2, 10, Arrays.asList(tale1, tale2));
+    Tale tale1 = new Tale("t1", new String[]{"word1", "word2"});
+    Tale tale2 = new Tale("t2", new String[]{"word2", "word3"});
+    testTales(2, 10, Arrays.asList(tale1, tale2));
   }
 }


### PR DESCRIPTION
Added example to calculate tf/idf metrics.
There are several known area to improve:
1. Test coverage could be better
2. Total number of documents is not calculated (could be added quickly if general approach is approved).
3. There are pretty much of code duplication and generic classes should be considered to avoid it.

Meanwhile scheme seems to be valid and robust enough to be candidate for submission and above mentioned issues could be solved separately.
