### PR TITLE
RegistryHolder should initialize after cluster

### DIFF
--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/FlameNode.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/FlameNode.java
@@ -43,7 +43,7 @@ public class FlameNode extends LoggingActor {
     ), "graph");
     graph.tell(resolvedManagers(), self());
 
-    final ActorRef negotiator = context().actorOf(Negotiator.props(acker, registryHolder, graph), "negotiator");
+    final ActorRef negotiator = context().actorOf(Negotiator.props(registryHolder, graph), "negotiator");
     this.edgeManager = context().actorOf(EdgeManager.props(config.paths().get(id), id, negotiator, graph), "edge");
   }
 

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/StartupWatcher.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/StartupWatcher.java
@@ -11,8 +11,6 @@ import com.spbsu.flamestream.runtime.config.CommitterConfig;
 import com.spbsu.flamestream.runtime.config.ZookeeperWorkersNode;
 import com.spbsu.flamestream.runtime.master.ClientWatcher;
 import com.spbsu.flamestream.runtime.master.acker.Acker;
-import com.spbsu.flamestream.runtime.master.acker.RegistryHolder;
-import com.spbsu.flamestream.runtime.master.acker.ZkRegistry;
 import com.spbsu.flamestream.runtime.serialization.FlameSerializer;
 import com.spbsu.flamestream.runtime.serialization.KryoSerializer;
 import com.spbsu.flamestream.runtime.state.DevNullStateStorage;
@@ -79,15 +77,13 @@ public class StartupWatcher extends LoggingActor {
             ActorPath$.MODULE$.fromString(self().path()
                     .toStringWithAddress(context().system().provider().getDefaultAddress()))
     );
-    ActorRef acker, registryHolder;
+    ActorRef acker;
     if (zookeeperWorkersNode.isLeader(id)) {
       acker = context().actorOf(Acker.props(committerConfig.defaultMinimalTime()), "acker");
-      registryHolder = context().actorOf(RegistryHolder.props(new ZkRegistry(curator), acker), "registry-holder");
       context().actorOf(ClientWatcher.props(curator, kryoSerializer, zookeeperWorkersNode), "client-watcher");
     } else {
       final ActorPath masterPath = ClusterConfig.fromWorkers(zookeeperWorkersNode.workers()).masterPath();
       acker = AwaitResolver.syncResolve(masterPath.child("acker"), context());
-      registryHolder = AwaitResolver.syncResolve(masterPath.child("registry-holder"), context());
     }
     context().actorOf(
             ProcessingWatcher.props(
@@ -97,8 +93,7 @@ public class StartupWatcher extends LoggingActor {
                     committerConfig,
                     stateStorage,
                     kryoSerializer,
-                    acker,
-                    registryHolder
+                    acker
             ),
             "processing-watcher"
     );

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/negitioator/Negotiator.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/negitioator/Negotiator.java
@@ -19,19 +19,17 @@ import java.util.Map;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class Negotiator extends LoggingActor {
-  private final ActorRef acker;
   private final ActorRef registryHolder;
   private final ActorRef source;
   private final Map<EdgeId, ActorRef> localFronts = new HashMap<>();
 
-  public Negotiator(ActorRef acker, ActorRef registryHolder, ActorRef source) {
-    this.acker = acker;
+  public Negotiator(ActorRef registryHolder, ActorRef source) {
     this.registryHolder = registryHolder;
     this.source = source;
   }
 
-  public static Props props(ActorRef acker, ActorRef registryHolder, ActorRef source) {
-    return Props.create(Negotiator.class, acker, registryHolder, source);
+  public static Props props(ActorRef registryHolder, ActorRef source) {
+    return Props.create(Negotiator.class, registryHolder, source);
   }
 
   @Override


### PR DESCRIPTION
В случае кластеризованного аккера `RegistryHolder` должен мочь регистрировать фронты на всех шардах, то есть знать про весь кластер.