### PR TITLE
Oracle Java 8 is not available anymore in Debian

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ addons:
   apt:
     packages:
       - sshpass
-      - oracle-java8-set-default
+      - oracle-java9-set-default
       - libgfortran3
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 
 cache:
   directories:


### PR DESCRIPTION
https://launchpad.net/~webupd8team/+archive/ubuntu/java