### PR TITLE
Order of classes serialized with kryo should be consistent

### DIFF
--- a/examples/src/main/java/com/spbsu/flamestream/example/benchmark/BenchStandComponentFactory.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/benchmark/BenchStandComponentFactory.java
@@ -41,7 +41,9 @@ public class BenchStandComponentFactory {
   ) throws IOException {
     final Server producer = new Server(1_000_000, 1000);
     producer.getKryo().register(type);
-    producer.getKryo().setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
+    ((Kryo.DefaultInstantiatorStrategy) producer.getKryo()
+            .getInstantiatorStrategy())
+            .setFallbackInstantiatorStrategy(new StdInstantiatorStrategy());
 
     producer.addListener(new Listener() {
       boolean accepted = false;
@@ -79,18 +81,20 @@ public class BenchStandComponentFactory {
           Class<Payload> type,
           Consumer<Payload> consumer,
           int port,
-          Class<?> ...classesToRegister
+          Class<?>... classesToRegister
   ) throws IOException {
     final Server server = new Server(2000, 1_000_000);
+    for (final Class<?> clazz : classesToRegister) {
+      server.getKryo().register(clazz);
+    }
     server.getKryo().register(PayloadDataItem.class);
     server.getKryo().register(Meta.class);
     server.getKryo().register(GlobalTime.class);
     server.getKryo().register(EdgeId.class);
     server.getKryo().register(int[].class);
-    for (final Class<?> clazz : classesToRegister) {
-      server.getKryo().register(clazz);
-    }
-    server.getKryo().setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
+    ((Kryo.DefaultInstantiatorStrategy) server.getKryo()
+            .getInstantiatorStrategy())
+            .setFallbackInstantiatorStrategy(new StdInstantiatorStrategy());
 
     server.addListener(new Listener() {
       @Override

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketRear.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketRear.java
@@ -33,6 +33,7 @@ public class SocketRear implements Rear {
   public SocketRear(EdgeContext edgeContext, String host, int port, Class[] classes) {
     edgeId = edgeContext.edgeId();
     client = new Client(1_000_000, 1234);
+    Arrays.stream(classes).forEach(clazz -> client.getKryo().register(clazz));
     { //register inners of data item
       client.getKryo().register(PayloadDataItem.class);
       client.getKryo().register(Meta.class);
@@ -40,7 +41,6 @@ public class SocketRear implements Rear {
       client.getKryo().register(EdgeId.class);
       client.getKryo().register(int[].class);
     }
-    Arrays.stream(classes).forEach(clazz -> client.getKryo().register(clazz));
 
     ((Kryo.DefaultInstantiatorStrategy) client.getKryo().getInstantiatorStrategy())
             .setFallbackInstantiatorStrategy(new StdInstantiatorStrategy());


### PR DESCRIPTION
Теперь `FlinkBench` запускается локально, хоть и сыпет следующей ошибкой в лог:
```
Exception in thread "Thread-0" org.jooq.lambda.UncheckedException: org.apache.flink.runtime.client.JobExecutionException: Could not retrieve JobResult.
```