### PR TITLE
Role flamestream-bench has nothing to destroy

### DIFF
--- a/benchmark/ansible/flamestream.yml
+++ b/benchmark/ansible/flamestream.yml
@@ -59,11 +59,6 @@
   roles:
     - { role: zookeeper-destroy }
 
-- name: Destroy bench
-  hosts: bench
-  roles:
-    - { role: flamestream-bench-destroy }
-
 - hosts: all
   tasks:
     - name: Fetch traces

--- a/benchmark/ansible/roles/flamestream-bench-destroy/tasks/main.yml
+++ b/benchmark/ansible/roles/flamestream-bench-destroy/tasks/main.yml
@@ -1,4 +1,0 @@
----
-- name: Destroy flame-bench
-  shell: pkill -f bench
-  ignore_errors: True


### PR DESCRIPTION
Бенч вызывается синхронно и файла `bench` даже нет.