### PR TITLE
Acking can be disabled without failures:

### DIFF
--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/ProcessingWatcher.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/ProcessingWatcher.java
@@ -156,7 +156,10 @@ public class ProcessingWatcher extends LoggingActor {
     final @Nullable ActorRef localAcker = ackers.isEmpty() ? null : context().actorOf(LocalAcker.props(ackers, id));
     final ActorRef committer, registryHolder;
     if (zookeeperWorkersNode.isLeader(id)) {
-      registryHolder = context().actorOf(RegistryHolder.props(new ZkRegistry(curator), ackers), "registry-holder");
+      registryHolder = context().actorOf(
+              RegistryHolder.props(new ZkRegistry(curator), ackers, systemConfig.defaultMinimalTime()),
+              "registry-holder"
+      );
       committer = context().actorOf(Committer.props(
               config.paths().size(),
               systemConfig,

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/graph/Component.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/graph/Component.java
@@ -199,8 +199,16 @@ public class Component extends LoggingActor {
             .match(DataItem.class, this::accept)
             .match(MinTimeUpdate.class, this::onMinTime)
             .match(NewRear.class, this::onNewRear)
-            .match(Heartbeat.class, h -> localAcker.forward(h, context()))
-            .match(UnregisterFront.class, u -> localAcker.forward(u, context()))
+            .match(Heartbeat.class, h -> {
+              if (localAcker != null) {
+                localAcker.forward(h, context());
+              }
+            })
+            .match(UnregisterFront.class, u -> {
+              if (localAcker != null) {
+                localAcker.forward(u, context());
+              }
+            })
             .match(Prepare.class, this::onPrepare)
             .match(Commit.class, this::onCommit)
             .build();


### PR DESCRIPTION
* RegistryHolder should give new fronts defaultMinimalTime
* Component should ignore acker messages when there are none