### PR TITLE
GraphDeployer::deploy should return front addresses

### DIFF
--- a/benchmark/flink-benchmark/src/main/java/com/spbsu/benchmark/flink/index/FlinkBench.java
+++ b/benchmark/flink-benchmark/src/main/java/com/spbsu/benchmark/flink/index/FlinkBench.java
@@ -19,8 +19,11 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.jooq.lambda.Unchecked;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
 
 public class FlinkBench {
   public static void main(String[] args) throws Exception {
@@ -36,7 +39,7 @@ public class FlinkBench {
     WikiBenchStand wikiBenchStand = new WikiBenchStand(benchConfig);
     wikiBenchStand.run(new GraphDeployer() {
       @Override
-      public void deploy() {
+      public Map<String, Handle> deploy() {
         final int parallelism = deployerConfig.getInt("parallelism");
         final StreamExecutionEnvironment environment;
         if (deployerConfig.hasPath("remote")) {
@@ -101,6 +104,10 @@ public class FlinkBench {
                 .setParallelism(parallelism);
         new Thread(Unchecked.runnable(environment::execute)).start();
 
+        return Collections.singletonMap("", new Handle(
+                new InetSocketAddress(wikiBenchStand.benchHost, wikiBenchStand.frontPort),
+                new InetSocketAddress(wikiBenchStand.benchHost, wikiBenchStand.rearPort)
+        ));
       }
 
       @Override

--- a/examples/src/main/java/com/spbsu/flamestream/example/benchmark/FlameGraphDeployer.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/benchmark/FlameGraphDeployer.java
@@ -1,7 +1,15 @@
 package com.spbsu.flamestream.example.benchmark;
 
+import akka.actor.Address;
 import com.spbsu.flamestream.core.Graph;
 import com.spbsu.flamestream.runtime.FlameRuntime;
+import com.spbsu.flamestream.runtime.edge.socket.SocketFrontType;
+import com.spbsu.flamestream.runtime.edge.socket.SocketRearType;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * User: Artem
@@ -10,13 +18,13 @@ import com.spbsu.flamestream.runtime.FlameRuntime;
 public class FlameGraphDeployer implements GraphDeployer {
   private final FlameRuntime runtime;
   private final Graph graph;
-  private final FlameRuntime.FrontType<?, ?> frontType;
-  private final FlameRuntime.RearType<?, ?> rearType;
+  private final SocketFrontType frontType;
+  private final SocketRearType rearType;
 
   public FlameGraphDeployer(FlameRuntime runtime,
                             Graph graph,
-                            FlameRuntime.FrontType<?, ?> frontType,
-                            FlameRuntime.RearType<?, ?> rearType) {
+                            SocketFrontType frontType,
+                            SocketRearType rearType) {
     this.runtime = runtime;
     this.graph = graph;
     this.frontType = frontType;
@@ -24,10 +32,22 @@ public class FlameGraphDeployer implements GraphDeployer {
   }
 
   @Override
-  public void deploy() {
+  public Map<String, Handle> deploy() {
     final FlameRuntime.Flame flame = runtime.run(graph);
-    flame.attachRear("FlameSocketGraphDeployerRear", rearType);
-    flame.attachFront("FlameSocketGraphDeployerFront", frontType);
+    return Stream.concat(
+            flame.attachFront("FlameSocketGraphDeployerFront", frontType),
+            flame.attachRear("FlameSocketGraphDeployerRear", rearType)
+    ).collect(Collectors.toSet()).stream().collect(Collectors.toMap(
+            edgeContext -> edgeContext.edgeId().nodeId(),
+            edgeContext -> {
+              final Address address = edgeContext.nodePath().address();
+              final InetSocketAddress inetSocketAddress = new InetSocketAddress(
+                      address.host().get(),
+                      ((scala.Int) address.port().get()).toInt()
+              );
+              return new Handle(inetSocketAddress, inetSocketAddress);
+            }
+    ));
   }
 
   @Override

--- a/examples/src/main/java/com/spbsu/flamestream/example/benchmark/GraphDeployer.java
+++ b/examples/src/main/java/com/spbsu/flamestream/example/benchmark/GraphDeployer.java
@@ -1,11 +1,23 @@
 package com.spbsu.flamestream.example.benchmark;
 
+import java.net.InetSocketAddress;
+import java.util.Map;
+
 /**
  * User: Artem
  * Date: 28.12.2017
  */
 public interface GraphDeployer extends AutoCloseable {
-  void deploy();
+  class Handle {
+    final InetSocketAddress front, rear;
+
+    public Handle(InetSocketAddress front, InetSocketAddress rear) {
+      this.front = front;
+      this.rear = rear;
+    }
+  }
+
+  Map<String, Handle> deploy();
 
   @Override
   void close();

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketFrontType.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketFrontType.java
@@ -7,7 +7,7 @@ import com.spbsu.flamestream.runtime.edge.EdgeContext;
  * User: Artem
  * Date: 28.12.2017
  */
-public class SocketFrontType implements FlameRuntime.FrontType<SocketFront, Void> {
+public class SocketFrontType implements FlameRuntime.FrontType<SocketFront, EdgeContext> {
   private final String host;
   private final int port;
   private final Class<?>[] inputClasses;
@@ -24,8 +24,8 @@ public class SocketFrontType implements FlameRuntime.FrontType<SocketFront, Void
   }
 
   @Override
-  public Void handle(EdgeContext context) {
-    return null;
+  public EdgeContext handle(EdgeContext context) {
+    return context;
   }
 
   private static class SocketFrontFrontInstance implements FlameRuntime.FrontInstance<SocketFront> {

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketRearType.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/socket/SocketRearType.java
@@ -7,7 +7,7 @@ import com.spbsu.flamestream.runtime.edge.EdgeContext;
  * User: Artem
  * Date: 29.12.2017
  */
-public class SocketRearType implements FlameRuntime.RearType<SocketRear, Void> {
+public class SocketRearType implements FlameRuntime.RearType<SocketRear, EdgeContext> {
   private final String host;
   private final int port;
   private final Class<?>[] outClasses;
@@ -24,8 +24,8 @@ public class SocketRearType implements FlameRuntime.RearType<SocketRear, Void> {
   }
 
   @Override
-  public Void handle(EdgeContext context) {
-    return null;
+  public EdgeContext handle(EdgeContext context) {
+    return context;
   }
 
   private static class SocketRearRearInstance implements FlameRuntime.RearInstance<SocketRear> {


### PR DESCRIPTION
Нужно, чтобы иметь возможность использовать в бенч стендах все фронты.