### PR TITLE
Tracking windows start should be aligned to start from first DataItem

### DIFF
--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/Front.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/edge/Front.java
@@ -25,9 +25,7 @@ public interface Front {
     }
 
     protected synchronized GlobalTime currentTime() {
-      long globalTs = prevGlobalTs + 1;
-      prevGlobalTs = globalTs;
-      return new GlobalTime(globalTs, edgeId);
+      return new GlobalTime(prevGlobalTs++, edgeId);
     }
   }
 }


### PR DESCRIPTION
Теперь при `defaultMinimalTime == 0` элементы будут идти с 0 времени.