### PR TITLE
Acker lastMinTime should be synchronized with AckTable.headValue

### DIFF
--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/ProcessingWatcher.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/ProcessingWatcher.java
@@ -165,7 +165,8 @@ public class ProcessingWatcher extends LoggingActor {
     ))));
     assert covering.isEmpty();
     final List<ActorRef> ackers = ackers(config);
-    final @Nullable ActorRef localAcker = ackers.isEmpty() ? null : context().actorOf(LocalAcker.props(ackers, id));
+    final @Nullable ActorRef localAcker = ackers.isEmpty() ? null
+            : context().actorOf(LocalAcker.props(ackers, id, systemConfig.defaultMinimalTime()));
     final ActorRef committer, registryHolder;
     if (zookeeperWorkersNode.isLeader(id)) {
       registryHolder = context().actorOf(
@@ -176,7 +177,7 @@ public class ProcessingWatcher extends LoggingActor {
               config.paths().size(),
               systemConfig,
               registryHolder,
-              new MinTimeUpdater(ackers)
+              new MinTimeUpdater(ackers, systemConfig.defaultMinimalTime())
       ), "committer");
     } else {
       final ActorPath masterPath = config.paths().get(config.masterLocation()).child("processing-watcher");

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/master/acker/LocalAcker.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/master/acker/LocalAcker.java
@@ -63,16 +63,16 @@ public class LocalAcker extends LoggingActor {
 
   private int flushCounter = 0;
 
-  public LocalAcker(List<ActorRef> ackers, String nodeId) {
+  public LocalAcker(List<ActorRef> ackers, String nodeId, long defaultMinimalTime) {
     this.ackers = ackers;
     partitions = new Partitions(ackers.size());
-    minTimeUpdater = new MinTimeUpdater(ackers);
+    minTimeUpdater = new MinTimeUpdater(ackers, defaultMinimalTime);
     this.nodeId = nodeId;
     pingActor = context().actorOf(PingActor.props(self(), Flush.FLUSH));
   }
 
-  public static Props props(List<ActorRef> ackers, String nodeId) {
-    return Props.create(LocalAcker.class, ackers, nodeId).withDispatcher("processing-dispatcher");
+  public static Props props(List<ActorRef> ackers, String nodeId, long defaultMinimalTime) {
+    return Props.create(LocalAcker.class, ackers, nodeId, defaultMinimalTime).withDispatcher("processing-dispatcher");
   }
 
   @Override

--- a/runtime/src/main/java/com/spbsu/flamestream/runtime/master/acker/MinTimeUpdater.java
+++ b/runtime/src/main/java/com/spbsu/flamestream/runtime/master/acker/MinTimeUpdater.java
@@ -1,6 +1,7 @@
 package com.spbsu.flamestream.runtime.master.acker;
 
 import akka.actor.ActorRef;
+import com.spbsu.flamestream.core.data.meta.EdgeId;
 import com.spbsu.flamestream.core.data.meta.GlobalTime;
 import com.spbsu.flamestream.runtime.master.acker.api.MinTimeUpdate;
 import com.spbsu.flamestream.runtime.master.acker.api.commit.MinTimeUpdateListener;
@@ -23,9 +24,10 @@ public class MinTimeUpdater {
 
   private Map<ActorRef, ShardState> shardStates;
 
-  private MinTimeUpdate lastMinTime = new MinTimeUpdate(GlobalTime.MIN, new NodeTimes());
+  private MinTimeUpdate lastMinTime;
 
-  public MinTimeUpdater(List<ActorRef> shards) {
+  public MinTimeUpdater(List<ActorRef> shards, long defaultMinimalTime) {
+    lastMinTime = new MinTimeUpdate(new GlobalTime(defaultMinimalTime, EdgeId.Min.INSTANCE), new NodeTimes());
     this.shardStates = shards.stream().collect(Collectors.toMap(Function.identity(), __ -> new ShardState()));
   }
 

--- a/runtime/src/test/java/com/spbsu/flamestream/runtime/FlameUmbrella.java
+++ b/runtime/src/test/java/com/spbsu/flamestream/runtime/FlameUmbrella.java
@@ -104,7 +104,7 @@ class Cluster extends LoggingActor {
                   throw new IllegalStateException("Unexpected value: " + acking);
               }
               final ActorRef localAcker = ackers.isEmpty() ? null : context.actorOf(
-                      LocalAcker.props(ackers, ""),
+                      LocalAcker.props(ackers, "", systemConfig.defaultMinimalTime()),
                       "localAcker"
               );
               final ActorRef registryHolder = context.actorOf(
@@ -115,7 +115,7 @@ class Cluster extends LoggingActor {
                       clusterConfig.paths().size(),
                       systemConfig,
                       registryHolder,
-                      new MinTimeUpdater(ackers)
+                      new MinTimeUpdater(ackers, systemConfig.defaultMinimalTime())
               ));
               return paths.keySet().stream().map(id -> context.actorOf(FlameNode.props(
                       id,

--- a/runtime/src/test/java/com/spbsu/flamestream/runtime/master/acker/MinTimeUpdaterTest.java
+++ b/runtime/src/test/java/com/spbsu/flamestream/runtime/master/acker/MinTimeUpdaterTest.java
@@ -5,7 +5,6 @@ import akka.actor.ActorSystem;
 import akka.testkit.TestProbe;
 import com.spbsu.flamestream.core.data.meta.EdgeId;
 import com.spbsu.flamestream.core.data.meta.GlobalTime;
-import com.spbsu.flamestream.runtime.graph.Joba;
 import com.spbsu.flamestream.runtime.master.acker.api.MinTimeUpdate;
 import org.testng.annotations.Test;
 
@@ -22,7 +21,7 @@ public class MinTimeUpdaterTest {
     final ArrayList<ActorRef> shards = new ArrayList<>();
     shards.add(shard1);
     shards.add(shard2);
-    final MinTimeUpdater minTimeUpdater = new MinTimeUpdater(shards);
+    final MinTimeUpdater minTimeUpdater = new MinTimeUpdater(shards, 0);
     final String id = "";
     final EdgeId edgeId = new EdgeId("", "");
     assertNull(minTimeUpdater.onShardMinTimeUpdate(


### PR DESCRIPTION
Выпилил метод с сайд-эффектами `minAmongTables`, который вместе с чтением значения двигал `AckTable`.